### PR TITLE
Responsivo das telas de autenticação

### DIFF
--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -64,6 +64,7 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
                     name="password"
                     placeholder="Your password"
                     required
+                    className="inputs"
                   />
                 </div>
                 <Link className="passwords-forgot" href="/forgot-password">

--- a/app/(auth-pages)/sign-in/sign-in.scss
+++ b/app/(auth-pages)/sign-in/sign-in.scss
@@ -9,9 +9,14 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   font-family: "Arial", sans-serif;
   background-color: #f1f1f1;
+  overflow-x: hidden;
 }
 
 .container__signup {
@@ -20,6 +25,7 @@ body {
   width: 100vw;
   overflow: hidden;
   color: #000;
+  background-color: #f1f1f1;
 
   &-left-side {
     position: relative;
@@ -48,14 +54,14 @@ body {
       margin-top: 20px;
       font-size: 2.5rem;
       font-weight: 700;
-      text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.6);
+      text-shadow: 2px 2px 6px #00000099;
       margin-bottom: 10px;
     }
 
     .subtitle {
       font-size: 1.2rem;
       max-width: 80%;
-      text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.6);
+      text-shadow: 1px 1px 4px #00000099;
     }
   }
 
@@ -186,5 +192,174 @@ body {
   .links {
     color: var(--primary-color);
     text-decoration: none;
+  }
+}
+
+@media (max-width: 915px) {
+  body {
+    .container__signup {
+      width: 915px;
+      align-items: center;
+      justify-content: center;
+
+      .container__signup-left-side {
+        display: none;
+      }
+
+      .container__signup-right-side {
+        width: 100%;
+        padding: 20px;
+
+        .form__login {
+          width: 100%;
+          margin-top: 0;
+        }
+
+        .form__login-banner {
+          div {
+            margin-top: 30;
+
+            span {
+              padding: 40px;
+            }
+          }
+        }
+
+        .form__login-authentication {
+          padding-top: 40px;
+
+          label {
+            font-size: 22px;
+          }
+
+          input {
+            width: 470px; /* Ajustei para ocupar toda a largura da tela */
+            font-size: 16px;
+            height: 55px;
+          }
+        }
+
+        .authentication-button {
+          .button {
+            font-size: 18px;
+            width: 470px;
+          }
+        }
+      }
+    }
+  }
+}
+@media (max-width: 740px) {
+  body {
+    .container__signup {
+      max-width: 740px;
+      align-items: center;
+      justify-content: center;
+
+      .container__signup-left-side {
+        display: none;
+      }
+
+      .container__signup-right-side {
+        width: 100%;
+        padding: 15px;
+
+        .form__login {
+          width: 100%;
+          margin-top: 0;
+        }
+
+        .form__login-banner {
+          div {
+            margin-top: 30px;
+
+            span {
+              padding: 30px;
+            }
+          }
+        }
+
+        .form__login-authentication {
+          padding-top: 30px;
+
+          label {
+            font-size: 20px;
+          }
+
+          input {
+            width: 410px;
+            font-size: 14px;
+            height: 50px;
+          }
+        }
+
+        .authentication-button {
+          .button {
+            font-size: 16px;
+            width: 410px;
+          }
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 430px) {
+  body {
+    .container__signup {
+      max-width: 560px;
+      align-items: center;
+      justify-content: center;
+
+      .container__signup-left-side {
+        display: none;
+      }
+
+      .container__signup-right-side {
+        width: 100%;
+        padding: 10px;
+
+        .form__login {
+          width: 100%;
+          margin-top: 20px;
+        }
+
+        .form__login-banner {
+          div {
+            margin-top: 20px;
+
+            span {
+              padding: 20px;
+            }
+          }
+        }
+
+        .form__login-authentication {
+          padding-top: 20px;
+
+          label {
+            font-size: 14px;
+          }
+
+          input {
+            width: 100%;
+            font-size: 14px;
+            height: 45px;
+          }
+        }
+
+        .authentication-button {
+          .button {
+            font-size: 14px;
+            width: 55%;
+          }
+        }
+        div {
+          p {
+            font-size: 15px;
+          }
+        }
+      }
+    }
   }
 }

--- a/app/(auth-pages)/sign-up/sign-up.scss
+++ b/app/(auth-pages)/sign-up/sign-up.scss
@@ -21,7 +21,7 @@ body {
     color: #000;
     font-family: "Arial", sans-serif;
     align-items: center; /* Alinhando o conteúdo ao centro verticalmente */
-    justify-content: center; /* Alinhamento simétrico no eixo horizontal */
+    justify-content: center;
 
     &__left-side,
     &__right-side {
@@ -35,15 +35,46 @@ body {
     }
 
     &__left-side {
-      background: url("/fundo.png") no-repeat center center/cover;
+      position: relative;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start; /* Alinha o conteúdo no topo */
+      height: 100%;
+      padding: 40px;
+      background: url("/fundo.jpg") no-repeat center center/cover;
       color: white;
-      text-align: center;
-      backdrop-filter: blur(8px); /* Suavizando o fundo com blur */
+      backdrop-filter: blur(8px);
+
+      &::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: #75737366;
+        z-index: 1;
+      }
+
+      .title {
+        margin-top: 1px;
+        font-size: 2.5rem;
+        font-weight: 700;
+        text-shadow: 2px 2px 6px #00000099;
+        margin-bottom: 10px;
+      }
+
+      .subtitle {
+        font-size: 1.2rem;
+        max-width: 80%;
+        text-shadow: 1px 1px 4px #00000099;
+      }
     }
 
     &__right-side {
-      background-color: #f1f1f1; /* Mantendo fundo leve */
-      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); /* Adicionando sombra para destaque */
+      background-color: #f1f1f1;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     }
   }
 }
@@ -220,4 +251,162 @@ body {
   position: relative;
   display: flex;
   align-items: center;
+}
+
+@media (max-width: 915px) {
+  .container__signin {
+    height: 100vh;
+    padding: 20px;
+    max-width: 915px;
+    background-color: #f1f1f1;
+
+    &__left-side {
+      display: none;
+    }
+
+    &__right-side {
+      width: 100%;
+      padding: 20px;
+      box-shadow: none;
+    }
+  }
+
+  .register {
+    max-width: 100%;
+    padding: 20px;
+
+    &__banner {
+      text-align: center;
+      gap: 10px;
+    }
+
+    &__title {
+      font-size: 28px;
+      text-align: center;
+    }
+
+    &__form {
+      gap: 16px;
+    }
+
+    &__form-group {
+      gap: 12px;
+
+      .input-two,
+      .inputs {
+        width: 100%;
+        padding: 20px 20px 20px 50px;
+      }
+
+      &-column {
+        gap: 40px;
+      }
+    }
+
+    &__radio {
+      gap: 12px; /* Reduz o espaçamento entre os botões */
+    }
+
+    &__submit {
+      font-size: 16px; /* Reduz o tamanho da fonte */
+      padding: 12px; /* Reduz o padding */
+    }
+
+    &__signup {
+      p {
+        font-size: 16px; /* Reduz o tamanho da fonte */
+      }
+    }
+  }
+}
+
+@media (max-width: 529px) {
+  .container__signin {
+    padding: 20px;
+    max-width: 100%;
+    background-color: #f1f1f1;
+    height: 100%;
+
+    &__left-side {
+      display: none;
+    }
+
+    &__right-side {
+      width: 100%;
+      padding: 20px;
+      box-shadow: none;
+      height: 100%;
+    }
+  }
+
+  .register {
+    max-width: 100%;
+    padding: 15px;
+
+    &__banner {
+      text-align: center;
+      gap: 10px;
+    }
+
+    &__title {
+      font-size: 28px;
+      text-align: center;
+      margin-bottom: 20px;
+    }
+
+    &__form {
+      gap: 16px;
+    }
+
+    &__form-group {
+      flex-direction: column;
+      width: 70%;
+      margin-top: 20px;
+    }
+
+    .inputs,
+    .input-two {
+      padding: 12px 60px;
+    }
+
+    &__form-group-column {
+      flex-direction: column;
+      width: 100%;
+    }
+
+    &__radio {
+      gap: 12px;
+      flex-direction: column;
+    }
+
+    &__submit {
+      font-size: 16px;
+      padding: 14px;
+      margin-top: 20px;
+      margin-bottom: 20px;
+    }
+
+    &__signup {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+
+      p {
+        font-size: 16px;
+        margin-bottom: 5px;
+      }
+
+      &-links {
+        font-size: 16px;
+        text-decoration: underline;
+        color: var(--color);
+        transition: color 0.3s ease;
+
+        &:hover {
+          color: #0f62fd;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fiz os responsivo das duas telas de autenticação: login e cadastro.

### Login
ocultei parte esquerda da tela para dispositivos de max-width melhor que 916px
Deixe itens do tamanho adequado para seus respectivos alturas

**Antes:**
![screenshot-1741901182658](https://github.com/user-attachments/assets/d747fe9c-28aa-40d0-ba41-b041e3bcb02a)


**Depois**
![screenshot-1741901273971](https://github.com/user-attachments/assets/2b6ae626-05de-46ff-83ec-acd4bf0b6c52)


### Cadastro
ocultei parte esquerda da tela para dispositivos de max-width melhor que 916px
Deixe itens do tamanho adequado para seus respectivos alturas

**Antes**
![screenshot-1741901340044](https://github.com/user-attachments/assets/715b37ba-a5f3-49d7-a7d7-d3200c536b3f)


**Depois**
![screenshot-1741901370182](https://github.com/user-attachments/assets/e283a0e1-8cac-431a-8ace-203b71d72181)



O que é preciso melhorar ainda? 
 - Exibições de erros
 - Cores
 - Imagem do lado esquerdo